### PR TITLE
feat(roles): Drone Operators have basic Engineering training

### DIFF
--- a/addons/roles/CfgRoles.inc
+++ b/addons/roles/CfgRoles.inc
@@ -191,6 +191,10 @@ class CfgRoles
       CamouflageCoef = 0.8;
       UAVHacker = TRAINED;
     };
+
+    class UnitVariables : UnitVariables {
+      ACE_isEngineer = TRAINED;
+    };
   };
 
   class AntiarmorSpecialist : Default


### PR DESCRIPTION
Allow UAV operators to repair their drones; this is necessary for some of the hacking stuff to work properly with Crow's EWAR.